### PR TITLE
Update `Masthead` so menu items without a page expand the sub menu instead

### DIFF
--- a/components/presenters/Docs/Masthead/Masthead.test.tsx
+++ b/components/presenters/Docs/Masthead/Masthead.test.tsx
@@ -16,6 +16,10 @@ import {
   MastheadSubMenuItem,
 } from '.'
 
+jest.mock('next/link', () => {
+  return ({ children }) => children
+})
+
 describe('Masthead', () => {
   let wrapper: RenderResult
 
@@ -30,7 +34,8 @@ describe('Masthead', () => {
               <MastheadMenuItem
                 link={<Link href="#principles">Principles</Link>}
               />
-              <MastheadMenuItem link={<Link href="#reference">Reference</Link>}>
+              {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+              <MastheadMenuItem link={<Link href="#">Reference</Link>}>
                 <MastheadSubMenu>
                   <MastheadSubMenuItem
                     link={<Link href="#design-tokens">Design Tokens</Link>}
@@ -54,6 +59,17 @@ describe('Masthead', () => {
 
     it('should not display the sub navigation', () => {
       expect(wrapper.queryByText('Design Tokens')).not.toBeInTheDocument()
+    })
+
+    it('should not set the `aria-label` attribute on the `Reference` menu item', () => {
+      expect(wrapper.getByText('Guidance')).not.toHaveAttribute('aria-label')
+    })
+
+    it('should set the `aria-label` attribute on the `Reference` menu item', () => {
+      expect(wrapper.getByText('Reference')).toHaveAttribute(
+        'aria-label',
+        'Show menu'
+      )
     })
 
     describe('and the user clicks the expand nav button', () => {
@@ -90,6 +106,53 @@ describe('Masthead', () => {
               wrapper.queryByTestId('masthead-sub-menu')
             ).not.toBeInTheDocument()
           })
+        })
+      })
+    })
+
+    describe('and the user clicks the menu item title', () => {
+      let clickEventSpy: MouseEvent
+
+      beforeEach(() => {
+        clickEventSpy = new MouseEvent('click', {
+          bubbles: true,
+          cancelable: true,
+        })
+
+        Object.assign(clickEventSpy, { preventDefault: jest.fn() })
+
+        fireEvent(wrapper.getByText('Reference'), clickEventSpy)
+      })
+
+      it('should invoke preventDefault', () => {
+        expect(clickEventSpy.preventDefault).toHaveBeenCalledTimes(1)
+      })
+
+      it('should show the sub navigation', () => {
+        expect(wrapper.queryByText('Design Tokens')).toBeInTheDocument()
+      })
+
+      it('should set the `aria-label` attribute on the `Reference` menu item', () => {
+        expect(wrapper.getByText('Reference')).toHaveAttribute(
+          'aria-label',
+          'Hide menu'
+        )
+      })
+
+      describe('and the user clicks the menu item title again', () => {
+        beforeEach(() => {
+          wrapper.getByText('Reference').click()
+        })
+
+        it('should hide the sub navigation', () => {
+          expect(wrapper.queryByText('Design Tokens')).not.toBeInTheDocument()
+        })
+
+        it('should set the `aria-label` attribute on the `Reference` menu item', () => {
+          expect(wrapper.getByText('Reference')).toHaveAttribute(
+            'aria-label',
+            'Show menu'
+          )
         })
       })
     })

--- a/components/presenters/Docs/Masthead/MastheadMenuItem.tsx
+++ b/components/presenters/Docs/Masthead/MastheadMenuItem.tsx
@@ -1,12 +1,11 @@
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 /* eslint-disable jsx-a11y/click-events-have-key-events */
-import React, { useState, useRef } from 'react'
-import { selectors } from '@royalnavy/design-tokens'
-import { IconExpandMore, IconExpandLess } from '@royalnavy/icon-library'
-import { useDocumentClick } from '@royalnavy/react-component-library'
+import React from 'react'
+import { IconExpandLess, IconExpandMore } from '@royalnavy/icon-library'
 
 import { ComponentWithClass } from '../../../../common/ComponentWithClass'
 
+import { StyledMastheadMenuButton } from './partials/StyledMastheadMenuButton'
 import { StyledMastheadMenuItem } from './partials/StyledMastheadMenuItem'
 import { StyledMastheadMenuLink } from './partials/StyledMastheadMenuLink'
 import { StyledExpandButton } from './partials/StyledExpandButton'
@@ -20,21 +19,41 @@ export const MastheadMenuItem: React.FC<MastheadMenuItemProps> = ({
   link,
   children,
 }) => {
-  const { isNotMobile, setShowChildren, showChildren, subMenuRef } =
-    useMastheadMenuItem()
+  const {
+    ariaLabel,
+    mediumBreakpointWidth,
+    buttonRef,
+    setShowChildren,
+    showChildren,
+    subMenuRef,
+  } = useMastheadMenuItem()
   const hasChildren = !!children
 
   return (
     <StyledMastheadMenuItem $hasChildren={hasChildren}>
       <div>
-        {React.cloneElement(link, {
-          passHref: true,
-          children: (
-            <StyledMastheadMenuLink>
-              {link.props.children}
-            </StyledMastheadMenuLink>
-          ),
-        })}
+        {link.props.href === '#' ? (
+          <StyledMastheadMenuButton
+            aria-label={ariaLabel}
+            data-testid="masthead-menu-link"
+            onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+              e.preventDefault()
+              setShowChildren(!showChildren)
+            }}
+            ref={buttonRef}
+          >
+            {link.props.children}
+          </StyledMastheadMenuButton>
+        ) : (
+          React.cloneElement(link, {
+            passHref: true,
+            children: (
+              <StyledMastheadMenuLink data-testid="masthead-menu-link">
+                {link.props.children}
+              </StyledMastheadMenuLink>
+            ),
+          })
+        )}
         {hasChildren && (
           <StyledExpandButton
             onClick={(_: React.MouseEvent<HTMLButtonElement>) =>
@@ -50,7 +69,7 @@ export const MastheadMenuItem: React.FC<MastheadMenuItemProps> = ({
         <div
           ref={subMenuRef}
           onClick={(_: React.MouseEvent<HTMLDivElement>) => {
-            if (isNotMobile) {
+            if (window.innerWidth >= mediumBreakpointWidth) {
               setShowChildren(false)
             }
           }}

--- a/components/presenters/Docs/Masthead/MastheadMenuItem.tsx
+++ b/components/presenters/Docs/Masthead/MastheadMenuItem.tsx
@@ -10,29 +10,19 @@ import { ComponentWithClass } from '../../../../common/ComponentWithClass'
 import { StyledMastheadMenuItem } from './partials/StyledMastheadMenuItem'
 import { StyledMastheadMenuLink } from './partials/StyledMastheadMenuLink'
 import { StyledExpandButton } from './partials/StyledExpandButton'
+import { useMastheadMenuItem } from './hooks/useMastheadMenuItem'
 
 export interface MastheadMenuItemProps extends ComponentWithClass {
   link?: React.ReactElement
 }
 
-const { breakpoint } = selectors
-
 export const MastheadMenuItem: React.FC<MastheadMenuItemProps> = ({
   link,
   children,
 }) => {
-  const subMenuRef = useRef()
-  const [showChildren, setShowChildren] = useState<boolean>(false)
+  const { isNotMobile, setShowChildren, showChildren, subMenuRef } =
+    useMastheadMenuItem()
   const hasChildren = !!children
-  const mediumBreakpointWidth = Number(
-    breakpoint('m').breakpoint.replace(/px/g, '')
-  )
-
-  useDocumentClick(subMenuRef, (_: Event) => {
-    if (window.innerWidth >= mediumBreakpointWidth) {
-      setShowChildren(false)
-    }
-  })
 
   return (
     <StyledMastheadMenuItem $hasChildren={hasChildren}>
@@ -60,7 +50,7 @@ export const MastheadMenuItem: React.FC<MastheadMenuItemProps> = ({
         <div
           ref={subMenuRef}
           onClick={(_: React.MouseEvent<HTMLDivElement>) => {
-            if (window.innerWidth >= mediumBreakpointWidth) {
+            if (isNotMobile) {
               setShowChildren(false)
             }
           }}

--- a/components/presenters/Docs/Masthead/MastheadSubMenuItem.tsx
+++ b/components/presenters/Docs/Masthead/MastheadSubMenuItem.tsx
@@ -17,7 +17,9 @@ export const MastheadSubMenuItem: React.FC<MastheadSubMenuItemProps> = ({
       {React.cloneElement(link, {
         passHref: true,
         children: (
-          <StyledMastheadMenuLink>{link.props.children}</StyledMastheadMenuLink>
+          <StyledMastheadMenuLink data-testid="masthead-sub-menu-link">
+            {link.props.children}
+          </StyledMastheadMenuLink>
         ),
       })}
     </StyledMastheadSubMenuItem>

--- a/components/presenters/Docs/Masthead/hooks/useMastheadMenuItem.ts
+++ b/components/presenters/Docs/Masthead/hooks/useMastheadMenuItem.ts
@@ -11,26 +11,31 @@ import {
 const { breakpoint } = selectors
 
 export function useMastheadMenuItem(): {
-  isNotMobile: boolean
+  ariaLabel: string
+  buttonRef: MutableRefObject<HTMLButtonElement>
+  mediumBreakpointWidth: number
   setShowChildren: Dispatch<SetStateAction<boolean>>
   showChildren: boolean
   subMenuRef: MutableRefObject<HTMLDivElement>
 } {
+  const buttonRef = useRef()
   const subMenuRef = useRef()
   const [showChildren, setShowChildren] = useState<boolean>(false)
   const mediumBreakpointWidth = Number(
     breakpoint('m').breakpoint.replace(/px/g, '')
   )
-  const isNotMobile = window.innerWidth >= mediumBreakpointWidth
+  const ariaLabel = showChildren ? 'Hide menu' : 'Show menu'
 
-  useDocumentClick(subMenuRef, (_: Event) => {
-    if (isNotMobile) {
+  useDocumentClick([buttonRef, subMenuRef], (_: Event) => {
+    if (window.innerWidth >= mediumBreakpointWidth && showChildren) {
       setShowChildren(false)
     }
   })
 
   return {
-    isNotMobile,
+    ariaLabel,
+    buttonRef,
+    mediumBreakpointWidth,
     setShowChildren,
     showChildren,
     subMenuRef,

--- a/components/presenters/Docs/Masthead/hooks/useMastheadMenuItem.ts
+++ b/components/presenters/Docs/Masthead/hooks/useMastheadMenuItem.ts
@@ -1,0 +1,38 @@
+import { selectors } from '@royalnavy/design-tokens'
+import { useDocumentClick } from '@royalnavy/react-component-library'
+import {
+  Dispatch,
+  MutableRefObject,
+  SetStateAction,
+  useRef,
+  useState,
+} from 'react'
+
+const { breakpoint } = selectors
+
+export function useMastheadMenuItem(): {
+  isNotMobile: boolean
+  setShowChildren: Dispatch<SetStateAction<boolean>>
+  showChildren: boolean
+  subMenuRef: MutableRefObject<HTMLDivElement>
+} {
+  const subMenuRef = useRef()
+  const [showChildren, setShowChildren] = useState<boolean>(false)
+  const mediumBreakpointWidth = Number(
+    breakpoint('m').breakpoint.replace(/px/g, '')
+  )
+  const isNotMobile = window.innerWidth >= mediumBreakpointWidth
+
+  useDocumentClick(subMenuRef, (_: Event) => {
+    if (isNotMobile) {
+      setShowChildren(false)
+    }
+  })
+
+  return {
+    isNotMobile,
+    setShowChildren,
+    showChildren,
+    subMenuRef,
+  }
+}

--- a/components/presenters/Docs/Masthead/partials/StyledMastheadMenuButton.tsx
+++ b/components/presenters/Docs/Masthead/partials/StyledMastheadMenuButton.tsx
@@ -1,0 +1,9 @@
+import styled from 'styled-components'
+
+import { StyledMastheadMenuLink } from './StyledMastheadMenuLink'
+
+export const StyledMastheadMenuButton = styled(StyledMastheadMenuLink)`
+  background-color: unset;
+  border-color: unset;
+  cursor: pointer;
+`

--- a/cypress/selectors/docs/index.ts
+++ b/cypress/selectors/docs/index.ts
@@ -2,6 +2,7 @@ import contentBlock from './contentBlock'
 import codeBlock from './codeBlock'
 import footer from './footer'
 import layout from './layout'
+import masthead from './masthead'
 import onThisPage from './onThisPage'
 import sidebar from './sidebar'
 
@@ -10,6 +11,7 @@ export default {
   codeBlock,
   footer,
   layout,
+  masthead,
   onThisPage,
   sidebar,
 }

--- a/cypress/selectors/docs/masthead.ts
+++ b/cypress/selectors/docs/masthead.ts
@@ -1,0 +1,5 @@
+export default {
+  expandButtons: '[data-testid="masthead-menu-expand-button"]',
+  menuLinks: '[data-testid="masthead-menu-link"]',
+  subMenuLinks: '[data-testid="masthead-sub-menu-link"]',
+}

--- a/cypress/specs/docs/masthead.spec.ts
+++ b/cypress/specs/docs/masthead.spec.ts
@@ -1,0 +1,99 @@
+import { cy, after, before } from 'local-cypress'
+
+import selectors from '../../selectors/docs'
+
+const items = [
+  {
+    title: 'Guidance',
+    hasPage: true,
+    subItems: [
+      'Design',
+      'Development',
+      'Installation & quick start',
+      'Learning resources',
+      'Migrating to v2',
+    ],
+  },
+  {
+    title: 'Reference',
+    subItems: ['Tokens', 'Components', 'Patterns', 'Frameworks'],
+  },
+  {
+    title: 'Resources',
+    hasPage: true,
+    subItems: ['Packages'],
+  },
+  { title: 'Help', hasPage: true },
+]
+
+describe('Masthead', () => {
+  describe('default', () => {
+    before(() => {
+      // Block newrelic.js due to issues with Cypress networking
+      cy.intercept('**/newrelic.js', (req) => {
+        req.reply("console.log('Fake New Relic script loaded');")
+      })
+
+      cy.visit('/')
+    })
+
+    items.forEach(({ title, hasPage, subItems }, itemIndex) => {
+      it(`should render the ${title} menu item`, () => {
+        cy.get(selectors.masthead.menuLinks)
+          .eq(itemIndex)
+          .should('have.text', title)
+      })
+
+      if (hasPage) {
+        describe(`when the ${title} menu item is clicked`, () => {
+          it(`should render the ${title} page`, () => {
+            cy.get(selectors.masthead.menuLinks)
+              .eq(itemIndex)
+              .click()
+              .get(selectors.layout.h1)
+              .should('have.text', title)
+              .go('back')
+          })
+        })
+      } else {
+        describe(`when the ${title} menu item is clicked`, () => {
+          before(() => {
+            cy.get(selectors.masthead.menuLinks).eq(itemIndex).click()
+          })
+
+          after(() => {
+            cy.get(selectors.masthead.menuLinks).eq(itemIndex).click()
+          })
+
+          subItems.forEach((subItem, subItemIndex) => {
+            it(`should render the ${subItem} sub item`, () => {
+              cy.get(selectors.masthead.subMenuLinks)
+                .eq(subItemIndex)
+                .should('have.text', subItem)
+            })
+          })
+        })
+      }
+
+      if (subItems) {
+        describe(`should render the ${title} sub items`, () => {
+          before(() => {
+            cy.get(selectors.masthead.expandButtons).eq(itemIndex).click()
+          })
+
+          after(() => {
+            cy.get(selectors.masthead.expandButtons).eq(itemIndex).click()
+          })
+
+          subItems.forEach((subItem, subItemIndex) => {
+            it(`should render the ${subItem} sub item`, () => {
+              cy.get(selectors.masthead.subMenuLinks)
+                .eq(subItemIndex)
+                .should('have.text', subItem)
+            })
+          })
+        })
+      }
+    })
+  })
+})

--- a/pages/[...slug].tsx
+++ b/pages/[...slug].tsx
@@ -351,11 +351,11 @@ export const GenericPage: React.FC<GenericPageProps> = ({
     </PageBanner>
   )
 
-  const isTabletOrMobile = useMediaQuery({
-    query: `(max-width: ${breakpoint('m').breakpoint})`,
+  const isDesktop = useMediaQuery({
+    query: `(min-width: ${breakpoint('m').breakpoint})`,
   })
 
-  const navigation = isTabletOrMobile ? mobileNavigation : desktopNavigation
+  const navigation = isDesktop ? desktopNavigation : mobileNavigation
 
   const masthead = (
     <Masthead version={version}>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -221,11 +221,11 @@ export const Home: React.FC<HomeProps> = ({
     </PageBanner>
   )
 
-  const isTabletOrMobile = useMediaQuery({
-    query: `(max-width: ${breakpoint('m').breakpoint})`,
+  const isDesktop = useMediaQuery({
+    query: `(min-width: ${breakpoint('m').breakpoint})`,
   })
 
-  const navigation = isTabletOrMobile ? mobileNavigation : desktopNavigation
+  const navigation = isDesktop ? desktopNavigation : mobileNavigation
 
   const masthead = (
     <Masthead version={version}>


### PR DESCRIPTION
## Related issue
Closes #315 

## Overview
Makes the items without a page present the sub menu when clicked.

## Reason
> Currently clicking the "Reference" link in the Masthead will not trigger its dropdown. As there isn't a page for /reference we should make it so the link itself triggers the dropdown - this also helps create a bigger click target for the dropdown.

## Work carried out
- [x] Add hook for menu item
- [x] Open sub menu for items without a page
- [x] Bolster Cypress tests around `Masthead`

## Screenshot
![2021-10-06 11 39 02](https://user-images.githubusercontent.com/56078793/136187809-074ad94b-f2ed-4c3e-8694-4692b9800fda.gif)