### PR TITLE
fix(OnThisPage): Fix browsing directly to a section

### DIFF
--- a/components/layouts/Legacy/Legacy.tsx
+++ b/components/layouts/Legacy/Legacy.tsx
@@ -7,7 +7,6 @@ import { ComponentWithClass } from '../../../common/ComponentWithClass'
 import { ContentBannerProps } from '../../presenters/Docs/ContentBanner'
 import { FooterProps } from '../../presenters/Docs/Footer'
 import { MastheadProps } from '../../presenters/Docs/Masthead'
-import { OnThisPageProps } from '../../presenters/Docs/OnThisPage'
 import { SidebarProps } from '../../presenters/Docs/Sidebar'
 import { StyledArticle } from './partials/StyledArticle'
 import { StyledBody } from './partials/StyledBody'
@@ -25,7 +24,7 @@ export interface LayoutComponentProps {
   contentBanner: React.ReactElement<ContentBannerProps>
   footer: React.ReactElement<FooterProps>
   masthead: React.ReactElement<MastheadProps>
-  onThisPage: React.ReactElement<OnThisPageProps>
+  onThisPage: React.ReactElement<ComponentWithClass>
   pageBanner?: React.ReactElement<ComponentWithClass>
   sidebar: React.ReactElement<SidebarProps>
   title: string

--- a/components/presenters/Docs/OnThisPage/OnThisPage.stories.tsx
+++ b/components/presenters/Docs/OnThisPage/OnThisPage.stories.tsx
@@ -10,7 +10,9 @@ const stories = storiesOf('Docs/OnThisPage', module)
 stories.add('Default', () => (
   <OnThisPage>
     <OnThisPageItem onClick={action('onClick')}>Overview</OnThisPageItem>
-    <OnThisPageItem onClick={action('onClick')}>Usage</OnThisPageItem>
+    <OnThisPageItem isActive onClick={action('onClick')}>
+      Usage
+    </OnThisPageItem>
     <OnThisPageItem onClick={action('onClick')}>Anatomy</OnThisPageItem>
     <OnThisPageItem onClick={action('onClick')}>
       Hierarchy &amp; placement

--- a/components/presenters/Docs/OnThisPage/OnThisPage.test.tsx
+++ b/components/presenters/Docs/OnThisPage/OnThisPage.test.tsx
@@ -80,4 +80,26 @@ describe('OnThisPage', () => {
       })
     })
   })
+
+  describe('the third item is active', () => {
+    beforeEach(() => {
+      onClickSpy = jest.fn()
+      wrapper = render(
+        <OnThisPage>
+          <OnThisPageItem onClick={onClickSpy}>1</OnThisPageItem>
+          <OnThisPageItem onClick={onClickSpy}>2</OnThisPageItem>
+          <OnThisPageItem isActive onClick={onClickSpy}>
+            3
+          </OnThisPageItem>
+          <OnThisPageItem onClick={onClickSpy}>4</OnThisPageItem>
+          <OnThisPageItem onClick={onClickSpy}>5</OnThisPageItem>
+        </OnThisPage>
+      )
+    })
+
+    it('should set the third item as active', () => {
+      const items = wrapper.getAllByTestId('on-this-page-item')
+      expectActive(items[2])
+    })
+  })
 })

--- a/components/presenters/Docs/OnThisPage/OnThisPage.tsx
+++ b/components/presenters/Docs/OnThisPage/OnThisPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React from 'react'
 
 import { ComponentWithClass } from '../../../../common/ComponentWithClass'
 import { OnThisPageItem, OnThisPageItemProps } from './OnThisPageItem'
@@ -6,18 +6,13 @@ import { StyledHeading } from './partials/StyledHeading'
 import { StyledItems } from './partials/StyledItems'
 import { StyledOnThisPage } from './partials/StyledOnThisPage'
 import { warnIfOverwriting } from '../../../helpers'
+import { useActiveItem } from './hooks/useActiveItem'
 
-export interface OnThisPageProps extends ComponentWithClass {
-  children:
-    | React.ReactElement<OnThisPageItemProps>
-    | React.ReactElement<OnThisPageItemProps>[]
-}
-
-export const OnThisPage: React.FC<OnThisPageProps> = ({
+export const OnThisPage: React.FC<ComponentWithClass> = ({
   children,
   className,
 }) => {
-  const [activeItemIndex, setActiveItemIndex] = useState<number>(0)
+  const { isActive, setActiveItemIndex } = useActiveItem(children)
 
   return (
     <StyledOnThisPage className={className}>
@@ -30,7 +25,7 @@ export const OnThisPage: React.FC<OnThisPageProps> = ({
 
             return React.cloneElement(child, {
               ...child.props,
-              isActive: index === activeItemIndex,
+              isActive: isActive(index),
               onClick: (e: React.MouseEvent<HTMLElement>) => {
                 setActiveItemIndex(index)
                 child.props.onClick(e)

--- a/components/presenters/Docs/OnThisPage/hooks/useActiveItem.ts
+++ b/components/presenters/Docs/OnThisPage/hooks/useActiveItem.ts
@@ -1,0 +1,31 @@
+import React, { Children, useEffect, useState } from 'react'
+
+function getActiveIndex(items: React.ReactNode): number {
+  const activeIndex = Children.toArray(items).findIndex(
+    (item: React.ReactNode) => {
+      return React.isValidElement(item) && item.props.isActive
+    }
+  )
+
+  return activeIndex > 0 ? activeIndex : 0
+}
+
+export function useActiveItem(children: React.ReactNode): {
+  isActive: (index: number) => boolean
+  setActiveItemIndex: (index: number) => void
+} {
+  const [activeItemIndex, setActiveItemIndex] = useState<number>()
+
+  useEffect(() => {
+    setActiveItemIndex(getActiveIndex(children))
+  }, [])
+
+  function isActive(index) {
+    return index === activeItemIndex
+  }
+
+  return {
+    isActive,
+    setActiveItemIndex,
+  }
+}

--- a/cypress/specs/docs/components.spec.ts
+++ b/cypress/specs/docs/components.spec.ts
@@ -201,4 +201,31 @@ describe('Docs Site: Components/Alert', () => {
       })
     })
   })
+
+  describe('when browsing directly to a section', () => {
+    const itemIndex = 3
+
+    before(() => {
+      // Block newrelic.js due to issues with Cypress networking
+      cy.intercept('**/newrelic.js', (req) => {
+        req.reply("console.log('Fake New Relic script loaded');")
+      })
+
+      cy.visit(`/components/alert#${itemIndex + 1}-sizing-spacing`)
+    })
+
+    it('should set the `OnThisPage` item as active', () => {
+      cy.get(selectors.onThisPage.item)
+        .eq(itemIndex)
+        .should(
+          'have.css',
+          'border-left',
+          `4px solid ${hexToRgb(color('neutral', '400'))}`
+        )
+    })
+
+    it('should navigate to the relevant sub-heading', () => {
+      cy.get(selectors.contentBlock.h2).eq(itemIndex).should('be.visible')
+    })
+  })
 })

--- a/pages/[...slug].tsx
+++ b/pages/[...slug].tsx
@@ -259,12 +259,27 @@ function renderOnThisPageItems(
 
   const { push } = useRouter()
 
+  function getCurrentSectionNumber() {
+    if (typeof window === 'undefined') {
+      return 0
+    }
+
+    return parseInt(window.location.hash.split('-')[0].substring(1), 10)
+  }
+
+  const currentSectionNumber = getCurrentSectionNumber()
+
   return h2Collection.map((item: Record<string, any>, index: number) => {
     const title = item?.content[0]?.value
-    const href = `#${kebabCase(`${index + 1}${title}`)}`
+    const sectionNumber = index + 1
+    const href = `#${kebabCase(`${sectionNumber}${title}`)}`
 
     return (
-      <OnThisPageItem key={href} onClick={(_) => push(href)}>
+      <OnThisPageItem
+        isActive={currentSectionNumber === sectionNumber}
+        key={href}
+        onClick={(_) => push(href)}
+      >
         {title}
       </OnThisPageItem>
     )


### PR DESCRIPTION
## Related issue
Fixes #331 

## Overview
When browsing directly to a section or refreshing a page then the section is not highlighted.

## Reason
> If you browse to /page#3-section then the corresponding OnThisPage item is not highlighted.

## Work carried out
- [x] Add fix