### PR TITLE
fix(Sidebar): Style active link

### DIFF
--- a/components/presenters/Docs/Sidebar/Sidebar.test.tsx
+++ b/components/presenters/Docs/Sidebar/Sidebar.test.tsx
@@ -4,11 +4,14 @@ import { IconBookmark } from '@royalnavy/icon-library'
 import Link from 'next/link'
 import { render, RenderResult, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { selectors } from '@royalnavy/design-tokens'
 
 import { Sidebar } from './Sidebar'
 import { SidebarFilter } from './SidebarFilter'
 import { SidebarMenu } from './SidebarMenu'
 import { SidebarMenuItem } from './SidebarMenuItem'
+
+const { color } = selectors
 
 describe('Sidebar', () => {
   let onChangeSpy: jest.SpyInstance
@@ -24,7 +27,10 @@ describe('Sidebar', () => {
     wrapper = render(
       <Sidebar title="Components">
         <SidebarMenu>
-          <SidebarMenuItem link={<Link href="#overview">Overview</Link>} />
+          <SidebarMenuItem
+            isActive
+            link={<Link href="#overview">Overview</Link>}
+          />
           <SidebarMenuItem
             icon={<IconBookmark data-testid="icon-1" />}
             link={<Link href="#storybook">Storybook</Link>}
@@ -45,6 +51,12 @@ describe('Sidebar', () => {
 
   it('should render the `Overview` link', () => {
     expect(wrapper.getByText('Overview')).toHaveAttribute('href', '/#overview')
+  })
+
+  it('should set the `Overview` link as active', () => {
+    expect(wrapper.getByText('Overview').parentElement).toHaveAttribute(
+      'aria-current'
+    )
   })
 
   it('should render the icon items', () => {

--- a/components/presenters/Docs/Sidebar/SidebarMenuItem.tsx
+++ b/components/presenters/Docs/Sidebar/SidebarMenuItem.tsx
@@ -9,6 +9,7 @@ import { StyledSidebarMenuItem } from './partials/StyledSidebarMenuItem'
 export interface SidebarMenuItemProps extends ComponentWithClass {
   icon?: React.ReactElement
   link: React.ReactElement<React.PropsWithChildren<LinkProps>>
+  isActive?: boolean
 }
 
 function getLink(link: React.ReactElement<React.PropsWithChildren<LinkProps>>) {
@@ -36,9 +37,10 @@ function getIconLink(
 export const SidebarMenuItem: React.FC<SidebarMenuItemProps> = ({
   icon,
   link,
+  isActive,
 }) => {
   return (
-    <StyledSidebarMenuItem>
+    <StyledSidebarMenuItem $isActive={isActive} aria-current={isActive}>
       {React.cloneElement(link, {
         ...link.props,
         children: icon ? getIconLink(icon, link) : getLink(link),

--- a/components/presenters/Docs/Sidebar/partials/StyledSidebarMenuItem.tsx
+++ b/components/presenters/Docs/Sidebar/partials/StyledSidebarMenuItem.tsx
@@ -1,6 +1,16 @@
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
+import { selectors } from '@royalnavy/design-tokens'
 
-export const StyledSidebarMenuItem = styled.li`
+import { StyledNavLink } from './StyledNavLink'
+import { StyledIconNavLink } from './StyledIconNavLink'
+
+interface StyledSidebarMenuItemProps {
+  $isActive?: boolean
+}
+
+const { color } = selectors
+
+export const StyledSidebarMenuItem = styled.li<StyledSidebarMenuItemProps>`
   display: flex;
   align-items: center;
   list-style: none;
@@ -8,4 +18,13 @@ export const StyledSidebarMenuItem = styled.li`
   padding: unset;
   height: 36px;
   display: block;
+
+  ${({ $isActive }) =>
+    $isActive &&
+    css`
+      ${StyledNavLink}, ${StyledIconNavLink} {
+        color: ${color('neutral', 'white')};
+        background-color: ${color('neutral', '500')};
+      }
+    `}
 `

--- a/pages/[...slug].tsx
+++ b/pages/[...slug].tsx
@@ -209,6 +209,11 @@ function renderSidebarItems(
   const grouped = groupBy(childrenCollection, 'contentfulMetadata.tags[0].name')
   const noGroup = grouped.undefined
   delete grouped.undefined
+  let pathname
+
+  if (typeof window !== 'undefined') {
+    pathname = window.location.pathname
+  }
 
   return (
     <>
@@ -219,6 +224,7 @@ function renderSidebarItems(
               <SidebarMenuItem
                 key={title}
                 link={<Link href={path || externalUri}>{title}</Link>}
+                isActive={path === pathname}
               />
             )
           })}
@@ -234,6 +240,7 @@ function renderSidebarItems(
                 <SidebarMenuItem
                   key={title}
                   link={<Link href={path || externalUri}>{title}</Link>}
+                  isActive={path === pathname}
                 />
               )
             })}


### PR DESCRIPTION
## Related issue

Closes #316

## Overview

Style `Sidebar` active item.

## Reason

>The link for the active page in the sidebar should be targetable to add additional styling (e.g. adding a BG colour and preventing users clicking).

## Work carried out

- [x] Add automated test
- [x] Apply aria attribute and style

## Screenshot

<img width="256" alt="Screenshot 2021-10-08 at 09 45 13" src="https://user-images.githubusercontent.com/48086589/136531253-d8d692b5-dbe8-4c2f-8b4a-7952b00ed131.png">


