### PR TITLE
Refactor Cypress tests to introduce `browseTo`, `blockNewRelic` commands

### DIFF
--- a/cypress/specs/docs/components.spec.ts
+++ b/cypress/specs/docs/components.spec.ts
@@ -23,10 +23,7 @@ const sections = [
 describe('Docs Site: Components', () => {
   describe('when browsing on desktop', () => {
     before(() => {
-      // Block newrelic.js due to issues with Cypress networking
-      cy.intercept('**/newrelic.js', (req) => {
-        req.reply("console.log('Fake New Relic script loaded');")
-      })
+      cy.blockNewRelic()
 
       cy.browseTo('Reference', 'Components')
     })
@@ -40,10 +37,7 @@ describe('Docs Site: Components', () => {
 describe('Docs Site: Components/Alert', () => {
   describe('when browsing on desktop', () => {
     before(() => {
-      // Block newrelic.js due to issues with Cypress networking
-      cy.intercept('**/newrelic.js', (req) => {
-        req.reply("console.log('Fake New Relic script loaded');")
-      })
+      cy.blockNewRelic()
 
       cy.browseTo('Reference', 'Components', 'Alert')
     })
@@ -206,10 +200,7 @@ describe('Docs Site: Components/Alert', () => {
     const itemIndex = 3
 
     before(() => {
-      // Block newrelic.js due to issues with Cypress networking
-      cy.intercept('**/newrelic.js', (req) => {
-        req.reply("console.log('Fake New Relic script loaded');")
-      })
+      cy.blockNewRelic()
 
       cy.visit(`/components/alert#${itemIndex + 1}-sizing-spacing`)
     })

--- a/cypress/specs/docs/homepage.spec.ts
+++ b/cypress/specs/docs/homepage.spec.ts
@@ -7,10 +7,7 @@ import selectors from '../../selectors/docs'
 describe('Docs Site: Homepage', () => {
   describe('when browsing on desktop', () => {
     before(() => {
-      // Block newrelic.js due to issues with Cypress networking
-      cy.intercept('**/newrelic.js', (req) => {
-        req.reply("console.log('Fake New Relic script loaded');")
-      })
+      cy.blockNewRelic()
 
       cy.visit('/')
     })
@@ -24,10 +21,7 @@ describe('Docs Site: Homepage', () => {
     },
     () => {
       before(() => {
-        // Block newrelic.js due to issues with Cypress networking
-        cy.intercept('**/newrelic.js', (req) => {
-          req.reply("console.log('Fake New Relic script loaded');")
-        })
+        cy.blockNewRelic()
 
         cy.visit('/')
       })

--- a/cypress/specs/docs/masthead.spec.ts
+++ b/cypress/specs/docs/masthead.spec.ts
@@ -29,10 +29,7 @@ const items = [
 describe('Masthead', () => {
   describe('default', () => {
     before(() => {
-      // Block newrelic.js due to issues with Cypress networking
-      cy.intercept('**/newrelic.js', (req) => {
-        req.reply("console.log('Fake New Relic script loaded');")
-      })
+      cy.blockNewRelic()
 
       cy.visit('/')
     })

--- a/cypress/specs/docs/styles.spec.ts
+++ b/cypress/specs/docs/styles.spec.ts
@@ -6,10 +6,7 @@ import selectors from '../../selectors/docs'
 describe('Docs Site: Tokens', () => {
   describe('when browsing on desktop', () => {
     before(() => {
-      // Block newrelic.js due to issues with Cypress networking
-      cy.intercept('**/newrelic.js', (req) => {
-        req.reply("console.log('Fake New Relic script loaded');")
-      })
+      cy.blockNewRelic()
 
       cy.browseTo('Reference', 'Tokens')
     })

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -43,4 +43,11 @@ Cypress.Commands.add('browseTo', (masthead, subMenu, sidebar) => {
   }
 })
 
+Cypress.Commands.add('blockNewRelic', () => {
+  // Block newrelic.js due to issues with Cypress networking
+  cy.intercept('**/newrelic.js', (req) => {
+    req.reply("console.log('Fake New Relic script loaded');")
+  })
+})
+
 export {}


### PR DESCRIPTION
## Related issue
Closes #358 

## Overview
Refactor to tidy up code.

## Reason
Evolving codebase.

## Work carried out
- [x] Add `browseTo`
- [x] Add `blockNewRelic`
- [x] Refactor