### PR TITLE
fix(CodeBlock): Adjust filename spacing

### DIFF
--- a/components/presenters/Framework/CodeBlock/partials/StyledFilename.tsx
+++ b/components/presenters/Framework/CodeBlock/partials/StyledFilename.tsx
@@ -7,7 +7,7 @@ export const StyledFilename = styled.span`
   display: block;
   font-weight: 400;
   color: ${color('neutral', '200')};
-  padding: 0 ${spacing('12')} ${spacing('8')} ${spacing('10')};
+  padding: ${spacing('12')} ${spacing('12')} 0 ${spacing('10')};
 
   ${mq({ gte: 's' })`
     padding-left: ${spacing('14')};


### PR DESCRIPTION
Fix minor spacing styling issue.

<img width="1381" alt="Screenshot 2021-10-12 at 15 57 14" src="https://user-images.githubusercontent.com/48086589/136980296-d31c5cbb-9d4e-4fc2-b75f-dba6e433aa5a.png">

