### PR TITLE
fix(Hero): Adjust description spacing

### DIFF
--- a/components/presenters/Docs/Hero/partials/StyledDescription.tsx
+++ b/components/presenters/Docs/Hero/partials/StyledDescription.tsx
@@ -11,8 +11,12 @@ export const StyledDescription = styled.p`
   padding: ${spacing('8')} 0;
   max-width: 550px;
 
+  ${mq({ gte: 's' })`
+    padding: ${spacing('8')};
+  `}
+
   ${mq({ gte: 'm' })`
-    padding: ${spacing('12')} 0;
+    padding: ${spacing('12')} ${spacing('8')};
     font-size: 18px;
     max-width: 660px;
   `}


### PR DESCRIPTION
## Overview

Needs to be adjusted post Contentful copy change.

## Screenshot

<img width="894" alt="Screenshot 2021-10-22 at 10 13 50" src="https://user-images.githubusercontent.com/48086589/138428161-abd295ab-50e0-4c58-8800-5a7540473524.png">