### PR TITLE
ci(GHA): Add failure notifications to release workflows

### DIFF
--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -46,3 +46,13 @@ jobs:
         if: steps.initversion.outputs.version != steps.postversion.outputs.version
         run: |
           curl -X POST -d {} ${{ secrets.TIMELINE_TOKEN }}
+
+      - name: Send notification on failure
+        if: failure()
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}
+        uses: defencedigital/design-system-slacknotify-action@master
+        with:
+          channel_id: C02H226CT33
+          status: FAILED
+          color: danger

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,3 +48,13 @@ jobs:
         if: steps.initversion.outputs.version != steps.postversion.outputs.version
         run: |
           curl -X POST -d {} ${{ secrets.TIMELINE_TOKEN }}
+
+      - name: Send notification on failure
+        if: failure()
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}
+        uses: defencedigital/design-system-slacknotify-action@master
+        with:
+          channel_id: C02H226CT33
+          status: FAILED
+          color: danger


### PR DESCRIPTION
## Related issue

closes #419 

## Overview

Add slack notifications for failed releases.

## Reason

As per design system

## Work carried out

- [x] Added bot token secret to repo
- [x] Added a 'Send notification on failure' step in the release workflows

