### PR TITLE
fix(Cypress): Add missing types post upgrade

### DIFF
--- a/cypress/support/global.d.ts
+++ b/cypress/support/global.d.ts
@@ -1,0 +1,8 @@
+/// <reference types="cypress" />
+
+declare namespace Cypress {
+  interface Chainable<Subject = any> {
+    browseTo: (masthead?: string, subMenu?: string, sidebar?: string) => void
+    blockNewRelic: () => void
+  }
+}


### PR DESCRIPTION
## Overview

This is currently breaking the build.

The following PR upstream will make this redundant once shipped: https://github.com/cypress-io/cypress/pull/19003