### PR TITLE
chore(Google): Add URL prefix site verification

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -14,7 +14,7 @@ module.exports = withPlugins([withTM], {
           options: {
             prettier: false,
             svgo: true,
-            svgoConfig: { plugins: [{ removeViewBox: false }] },
+            svgoConfig: { plugins: [] },
             titleProp: true,
           },
         },

--- a/public/googlec53f8692bc02cf64.html
+++ b/public/googlec53f8692bc02cf64.html
@@ -1,0 +1,1 @@
+google-site-verification: googlec53f8692bc02cf64.html


### PR DESCRIPTION
## Overview

The requested TXT record was unable to be added due to the site sitting on a CNAME.

I've since found an alternative way of enable the search console.

https://support.google.com/webmasters/answer/9008080#html_verification&zippy=%2Chtml-file-upload