### PR TITLE
ci(Dependabot): Limit automerge to patch and minor

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,4 +1,4 @@
-name: Automerge
+name: Dependabot Automerge
 
 on:
   workflow_run:
@@ -9,9 +9,7 @@ on:
     branches:
       - 'dependabot/**'
 
-
 jobs:
-
   Test_docs-site:
       runs-on: ubuntu-latest
       if: ${{ github.event.workflow_run.conclusion == 'success' }}
@@ -44,8 +42,6 @@ jobs:
           env:
            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
            SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-
-
   Test-e2e_docs-site:
       runs-on: ubuntu-latest
       if: ${{ github.event.workflow_run.conclusion == 'success' }}
@@ -68,15 +64,13 @@ jobs:
           with:
             name: cypress_screenshots
             path: cypress/screenshots/
-
-
   Automerge:
     name: Merge Dependabot PR's
     runs-on: ubuntu-latest
     needs: [Test_docs-site, Test-e2e_docs-site]
     steps:
-
-      - name: Run merge me action
+      - name: Auto merge Dependabot minor and patch version bumps
         uses: defencedigital/design-system-mergeme-action@master
         with:
           GITHUB_TOKEN: ${{ secrets.MERGE_BOT }}
+          PRESET: DEPENDABOT_MINOR

--- a/.github/workflows/build_and_test_feature.yml
+++ b/.github/workflows/build_and_test_feature.yml
@@ -20,8 +20,6 @@ jobs:
             yarn install --cache-folder ~/.cache/yarn
             node ./scripts/commitlint ${{ github.event.pull_request._links.html.href }}
             node ./scripts/check-fixup ${{ github.event.pull_request._links.html.href }}
-
-
     Security_audit:
       runs-on: ubuntu-latest
       steps:
@@ -30,7 +28,6 @@ jobs:
 
         - name: Run audit
           run: yarn run audit
-
 
     Lint_docs-site:
       runs-on: ubuntu-latest
@@ -51,10 +48,10 @@ jobs:
             yarn install --cache-folder ~/.cache/yarn
             yarn lint:ci
 
-
     Test_docs-site:
       runs-on: ubuntu-latest
       needs: [Lint_docs-site]
+      # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
       if: ${{ github.actor != 'dependabot[bot]' }}
       steps:
         - name: Git clone repository
@@ -91,10 +88,10 @@ jobs:
            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
            SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
-
     Test-e2e_docs-site:
       runs-on: ubuntu-latest
       needs: [Lint_docs-site]
+      # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
       if: ${{ github.actor != 'dependabot[bot]' }}
       env:
             NEXT_PUBLIC_CONTENTFUL_SPACE_ID: ${{ secrets.NEXT_PUBLIC_CONTENTFUL_SPACE_ID }}
@@ -120,5 +117,3 @@ jobs:
           with:
             name: cypress_screenshots
             path: cypress/screenshots/
-
-


### PR DESCRIPTION
## Overview

Use existing action preset functionality to restrict automerge to minor and patch releases.

https://github.com/defencedigital/design-system-mergeme-action#presets