### PR TITLE
fix(PageBanner): Update upgrade guide link

### DIFF
--- a/cypress/selectors/docs/homepage.ts
+++ b/cypress/selectors/docs/homepage.ts
@@ -6,5 +6,8 @@ export default {
   hero: {
     title: '[data-testid="hero-title"]',
   },
+  pageBanner: {
+    link: '[data-testid="page-banner-link"]',
+  },
   sectionTitles: '[data-testid="section-title"]',
 }

--- a/cypress/specs/docs/homepage.spec.ts
+++ b/cypress/specs/docs/homepage.spec.ts
@@ -40,6 +40,11 @@ describe('Docs Site: Homepage', () => {
         cy.visit('/')
       })
 
+      it('should render the page banner', () => {
+        cy.get(selectors.homepage.pageBanner.link).should('have.text', 'Read the upgrade guide')
+        cy.get(selectors.homepage.pageBanner.link).should('have.attr', 'href', '/guidance/migrating-to-v3')
+      })
+
       it('should render the hero', () => {
         cy.get(selectors.homepage.hero.title).should('be.visible')
       })

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -216,7 +216,7 @@ export const Home: React.FC<HomeProps> = ({
     <PageBanner>
       Version <Badge variant={BADGE_VARIANT.DARK}>{version}</Badge> has been
       released!&nbsp;
-      <a href="/guidance/migrating-to-v2">
+      <a data-testid="page-banner-link" href="/guidance/migrating-to-v3">
         Read the <strong>upgrade guide</strong>
       </a>
     </PageBanner>


### PR DESCRIPTION
Fix the upgrade guide link.

![Screenshot 2022-03-02 at 11 43 53](https://user-images.githubusercontent.com/56078793/156355614-603b227a-cddd-43fa-a074-a18e37dc0464.png)