### PR TITLE
chore(CODEOWNERS): Update CODEOWNERS and Dependabot reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,4 +5,4 @@
 # the repo. Unless a later match takes precedence,
 # @thyhjwb6, @m7kvqbe1 and @jpveooys will be requested for
 # review when someone opens a pull request.
-*       @thyhjwb6 @m7kvqbe1 @jpveooys
+*       @jpveooys

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,6 @@ updates:
   schedule:
     interval: weekly
   open-pull-requests-limit: 5
-  reviewers:
-  - m7kvqbe1
-  - thyhjwb6
   labels:
   - "Type: Dependencies"
   commit-message:


### PR DESCRIPTION
## Overview

This updates the CODEOWNERS file to remove those no longer on the project, and also removes reviewers from the Dependabot configuration as CODEOWNERS should be adding reviewers already.
