### PR TITLE
ci(GHA): Update all actions to latest versions

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -15,10 +15,10 @@ jobs:
       if: ${{ github.event.workflow_run.conclusion == 'success' }}
       steps:
         - name: Git clone repository
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
 
         - name: Cache Node modules
-          uses: actions/cache@v2
+          uses: actions/cache@v3
           with:
             path: '**/node_modules'
             key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
@@ -50,17 +50,17 @@ jobs:
             NEXT_PUBLIC_CONTENTFUL_ACCESS_TOKEN: ${{ secrets.NEXT_PUBLIC_CONTENTFUL_ACCESS_TOKEN }}
       steps:
         - name: Git clone repository
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
 
         - name: Run e2e tests
-          uses: cypress-io/github-action@v4
+          uses: cypress-io/github-action@v5
           with:
             build: yarn build
             start: yarn start
 
         - name: Save images for failed tests
           if: failure()
-          uses: actions/upload-artifact@v2
+          uses: actions/upload-artifact@v3
           with:
             name: cypress_screenshots
             path: cypress/screenshots/

--- a/.github/workflows/branch_deploy.yml
+++ b/.github/workflows/branch_deploy.yml
@@ -14,7 +14,7 @@ jobs:
       PREVIEW_URL: https://deploy-preview--peaceful-wiles-97aae8.netlify.app
     steps:
     - name: Git clone repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name:  Fetch all commits
       run: git fetch --all

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -13,10 +13,10 @@ jobs:
       if: ${{ github.event_name == 'pull_request' }}
       steps:
         - name: Git clone repository
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
 
         - name: Cache Node modules
-          uses: actions/cache@v2
+          uses: actions/cache@v3
           with:
             path: '**/node_modules'
             key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
@@ -38,7 +38,7 @@ jobs:
       runs-on: ubuntu-latest
       steps:
         - name: Git clone repository
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
 
         - name: Run audit
           run: yarn run audit
@@ -49,10 +49,10 @@ jobs:
         ESLINT_JUNIT_OUTPUT: "test-results/eslint/docs-site-results.xml"
       steps:
         - name: Git clone repository
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
 
         - name: Cache Node modules
-          uses: actions/cache@v2
+          uses: actions/cache@v3
           with:
             path: '**/node_modules'
             key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
@@ -69,10 +69,10 @@ jobs:
       if: ${{ github.actor != 'dependabot[bot]' }}
       steps:
         - name: Git clone repository
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
 
         - name: Cache Node modules
-          uses: actions/cache@v2
+          uses: actions/cache@v3
           with:
             path: '**/node_modules'
             key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
@@ -112,7 +112,7 @@ jobs:
             NEXT_PUBLIC_CONTENTFUL_ACCESS_TOKEN: ${{ secrets.NEXT_PUBLIC_CONTENTFUL_ACCESS_TOKEN }}
       steps:
         - name: Git clone repository
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
 
         - name: Switch Contentful Environment
           if: contains(github.ref, 'staging')
@@ -120,14 +120,14 @@ jobs:
             echo "NEXT_PUBLIC_CONTENTFUL_ENVIRONMENT=staging" >> $GITHUB_ENV
 
         - name: Run e2e tests
-          uses: cypress-io/github-action@v4
+          uses: cypress-io/github-action@v5
           with:
             build: yarn build
             start: yarn start
 
         - name: Save images for failed tests
           if: failure()
-          uses: actions/upload-artifact@v2
+          uses: actions/upload-artifact@v3
           with:
             name: cypress_screenshots
             path: cypress/screenshots/

--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
         # pulls all commits (needed for semantic release to correctly version)
          fetch-depth: 0
@@ -19,7 +19,7 @@ jobs:
         run: git fetch --all --tags
 
       - name: Cache Node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/project_stale_issues.yml
+++ b/.github/workflows/project_stale_issues.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add label & comment to stale issues
-        uses: actions/stale@v3
+        uses: actions/stale@v7
         with:
           stale-issue-message: 'This issue has been marked as stale because it has been open for 60 days with no activity'
           days-before-stale: 60

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
         # pulls all commits (needed for semantic release to correctly version)
          fetch-depth: 0
@@ -21,7 +21,7 @@ jobs:
         run: git fetch --all --tags
 
       - name: Cache Node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}


### PR DESCRIPTION
## Overview

This uploads all actions to their latest versions, to resolve warnings about actions using Node.js 12 no longer being supported.

## Work carried out

- [x] Update the versions of all actions

## Developer notes

There should be no relevant breaking changes in these updates.
