### PR TITLE
Update Cypress to version 12 and use Chrome on GitHub Actions

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -122,6 +122,7 @@ jobs:
         - name: Run e2e tests
           uses: cypress-io/github-action@v5
           with:
+            browser: chrome
             build: yarn build
             start: yarn start
 

--- a/cypress/e2e/docs/homepage.cy.ts
+++ b/cypress/e2e/docs/homepage.cy.ts
@@ -34,15 +34,22 @@ describe('Docs Site: Homepage', () => {
       viewportWidth: 1200,
     },
     () => {
-      before(() => {
+      beforeEach(() => {
         cy.blockNewRelic()
 
         cy.visit('/')
       })
 
       it('should render the page banner', () => {
-        cy.get(selectors.homepage.pageBanner.link).should('have.text', 'Read the upgrade guide')
-        cy.get(selectors.homepage.pageBanner.link).should('have.attr', 'href', '/guidance/migrating-to-v3')
+        cy.get(selectors.homepage.pageBanner.link).should(
+          'have.text',
+          'Read the upgrade guide'
+        )
+        cy.get(selectors.homepage.pageBanner.link).should(
+          'have.attr',
+          'href',
+          '/guidance/migrating-to-v3'
+        )
       })
 
       it('should render the hero', () => {
@@ -130,35 +137,47 @@ describe('Docs Site: Homepage', () => {
       viewportWidth: 500,
     },
     () => {
-      before(() => {
+      beforeEach(() => {
         cy.blockNewRelic()
 
         cy.visit('/')
       })
 
       describe('when the mobile navigation is opened', () => {
-        it('should open the mobile navigation', () => {
+        beforeEach(() => {
           cy.get(selectors.layout.mastheadToggleButton).click()
+        })
+
+        it('should open the mobile navigation', () => {
           cy.get(selectors.layout.mastheadMenuExpandButton).should('be.visible')
         })
 
         describe('and the first sub menu group is expanded', () => {
-          it('should expand the relevant sub menu', () => {
+          beforeEach(() => {
             cy.get(selectors.layout.mastheadMenuExpandButton).eq(0).click()
+          })
+
+          it('should expand the relevant sub menu', () => {
             cy.get('a').contains(LEARNING_RESOURCES).should('be.visible')
             cy.get('a').contains(COLOUR_TOKENS).should('not.exist')
           })
 
           describe('and the second sub menu group is expanded', () => {
-            it('should expand the relevant sub menu', () => {
+            beforeEach(() => {
               cy.get(selectors.layout.mastheadMenuExpandButton).eq(1).click()
+            })
+
+            it('should expand the relevant sub menu', () => {
               cy.get('a').contains(LEARNING_RESOURCES).should('be.visible')
               cy.get('a').contains(COLOUR_TOKENS).should('be.visible')
             })
 
             describe('and the first sub menu group is collapsed', () => {
-              it('should collapse the relevant sub menu', () => {
+              beforeEach(() => {
                 cy.get(selectors.layout.mastheadMenuExpandButton).eq(0).click()
+              })
+
+              it('should collapse the relevant sub menu', () => {
                 cy.get('a').contains(LEARNING_RESOURCES).should('not.exist')
                 cy.get('a').contains(COLOUR_TOKENS).should('be.visible')
               })
@@ -169,9 +188,7 @@ describe('Docs Site: Homepage', () => {
         describe('when clicking outside the mobile menu', () => {
           it('should close the mobile menu', () => {
             cy.get(selectors.layout.masthead).click()
-            cy.get(selectors.layout.mastheadMenuExpandButton).should(
-              'be.visible'
-            )
+            cy.get(selectors.layout.mastheadToggleButton).should('be.visible')
           })
         })
       })

--- a/cypress/e2e/docs/masthead.cy.ts
+++ b/cypress/e2e/docs/masthead.cy.ts
@@ -28,7 +28,7 @@ const items = [
 
 describe('Masthead', () => {
   describe('default', () => {
-    before(() => {
+    beforeEach(() => {
       cy.blockNewRelic()
 
       cy.visit('/')
@@ -53,11 +53,7 @@ describe('Masthead', () => {
         })
       } else {
         describe(`when the ${title} menu item is clicked`, () => {
-          before(() => {
-            cy.get(selectors.masthead.menuLinks).eq(itemIndex).click()
-          })
-
-          after(() => {
+          beforeEach(() => {
             cy.get(selectors.masthead.menuLinks).eq(itemIndex).click()
           })
 
@@ -73,11 +69,7 @@ describe('Masthead', () => {
 
       if (subItems) {
         describe(`should render the ${title} sub items`, () => {
-          before(() => {
-            cy.get(selectors.masthead.expandButtons).eq(itemIndex).click()
-          })
-
-          after(() => {
+          beforeEach(() => {
             cy.get(selectors.masthead.expandButtons).eq(itemIndex).click()
           })
 

--- a/cypress/e2e/docs/styles.cy.ts
+++ b/cypress/e2e/docs/styles.cy.ts
@@ -5,7 +5,7 @@ import selectors from '../../selectors/docs'
 
 describe('Docs Site: Tokens', () => {
   describe('when browsing on desktop', () => {
-    before(() => {
+    beforeEach(() => {
       cy.blockNewRelic()
 
       cy.browseTo('Reference', 'Tokens')

--- a/cypress/e2e/timeline/index.cy.ts
+++ b/cypress/e2e/timeline/index.cy.ts
@@ -59,7 +59,7 @@ const content = [
 
 describe('Compound Timeline', () => {
   describe('when browsing on desktop', () => {
-    before(() => {
+    beforeEach(() => {
       // Block newrelic.js due to issues with Cypress networking
       cy.intercept('**/newrelic.js', (req) => {
         req.reply("console.log('Fake New Relic script loaded');")

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "babel-plugin-import-graphql": "^2.8.1",
     "babel-plugin-styled-components": "^2.0.7",
     "babel-polyfill": "^6.26.0",
-    "cypress": "10.9.0",
+    "cypress": "12.10.0",
     "eslint": "^8.25.0",
     "eslint-config-next": "^12.2.5",
     "eslint-config-prettier": "^8.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9170,11 +9170,6 @@ commander@^4.1.1:
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
   integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
 
-commander@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
-  integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
-
 commander@^6.2.1:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
@@ -9767,10 +9762,10 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
-cypress@10.9.0:
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-10.9.0.tgz#273a61a6304766f9d6423e5ac8d4a9a11ed8b485"
-  integrity sha512-MjIWrRpc+bQM9U4kSSdATZWZ2hUqHGFEQTF7dfeZRa4MnalMtc88FIE49USWP2ZVtfy5WPBcgfBX+YorFqGElA==
+cypress@12.10.0:
+  version "12.10.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.10.0.tgz#b6264f77c214d63530ebac2b33c4d099bd40b715"
+  integrity sha512-Y0wPc221xKKW1/4iAFCphkrG2jNR4MjOne3iGn4mcuCaE7Y5EtXL83N8BzRsAht7GYfWVjJ/UeTqEdDKHz39HQ==
   dependencies:
     "@cypress/request" "^2.88.10"
     "@cypress/xvfb" "^1.2.4"
@@ -9786,10 +9781,10 @@ cypress@10.9.0:
     check-more-types "^2.24.0"
     cli-cursor "^3.1.0"
     cli-table3 "~0.6.1"
-    commander "^5.1.0"
+    commander "^6.2.1"
     common-tags "^1.8.0"
     dayjs "^1.10.4"
-    debug "^4.3.2"
+    debug "^4.3.4"
     enquirer "^2.3.6"
     eventemitter2 "6.4.7"
     execa "4.1.0"
@@ -9804,7 +9799,7 @@ cypress@10.9.0:
     listr2 "^3.8.3"
     lodash "^4.17.21"
     log-symbols "^4.0.0"
-    minimist "^1.2.6"
+    minimist "^1.2.8"
     ospath "^1.2.2"
     pretty-bytes "^5.6.0"
     proxy-from-env "1.0.0"
@@ -15172,6 +15167,11 @@ minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.7.tgz#daa1c4d91f507390437c6a8bc01078e7000c4d18"
   integrity sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==
+
+minimist@^1.2.8:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
+  integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
 minipass-collect@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
## Overview

This updates Cypress from version 10 to version 12, and makes it use Chrome on GitHub Actions (instead of Electron).

## Reason

Get Cypress on the latest version.

There was previously some flakiness when running the Timeline tests on GitHub Actions. I can also reproduce it locally if the CPU is stressed when running Cypress. I wasn't able to reproduce the flakiness with Chrome locally, hence this switches to that on CI as well.

## Work carried out

- [x] Update Cypress
- [x] Update e2e tests
- [x] Change Cypress browser on CI

## Developer notes

By default, Cypress now isolates tests. This required updates to some tests so that they aren't dependent on previous tests.
