### PR TITLE
test(Timeline): Disable smooth scrolling in Cypress

### DIFF
--- a/cypress/e2e/timeline/index.cy.ts
+++ b/cypress/e2e/timeline/index.cy.ts
@@ -66,6 +66,8 @@ describe('Compound Timeline', () => {
       })
 
       cy.visit('/timeline')
+
+      cy.get('main').invoke('css', 'scroll-behavior', 'auto')
     })
 
     it('should render the sidebar title', () => {


### PR DESCRIPTION
## Overview

The Timeline tests have still been flakey on GitHub Actions.

This disables smooth scrolling for them in Cypress to hopefully fix it. (Smooth scrolling didn't make much sense here either during the tests as the tests check if something was scrolled to, so you could get a false positive if it scrolls past the target.)
